### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/aaron-vaz/skelly/security/code-scanning/1](https://github.com/aaron-vaz/skelly/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow or specifically to the job(s) that do not currently restrict the `GITHUB_TOKEN` permissions. Since the workflow only requires source code read access for linting, building, testing, and installing dependencies (and does not publish releases, comment on issues, or create PRs), the permission can be set to `contents: read` at the workflow root, which applies to all jobs. Insert this block immediately after the workflow `name:` directive and before the `on:` key for clarity and compatibility. No additional library imports or changes to the existing steps are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
